### PR TITLE
Force port of webpack dev server to 8081

### DIFF
--- a/frontend/clean-community/vue.config.js
+++ b/frontend/clean-community/vue.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   devServer: {
-    proxy: 'http://localhost:8080'
+    proxy: 'http://localhost:8080',
+    port: 8081
   }
 }


### PR DESCRIPTION
If the backend server isn't started before the webpack dev server, they both collide on 8080.  This commit forces the dev server to be on 8081, leaving 8080 open for the backend.